### PR TITLE
Enable Lucene text searches for author and license, via faceting

### DIFF
--- a/app/tests/search/test_gleaner.py
+++ b/app/tests/search/test_gleaner.py
@@ -165,7 +165,7 @@ class TestGleanerSearch(unittest.TestCase):
             author = 'Anonymous'
         )
 
-        self.assertIn("CONTAINS(?author, '''Anonymous''')", self.search.query)
+        self.assertIn("luc:query '''author:Anonymous'''", self.search.query)
 
     @patch('SPARQLWrapper.SPARQLWrapper.query')
     def test_combined_search(self, query):

--- a/docker/gleaner.yaml
+++ b/docker/gleaner.yaml
@@ -41,7 +41,7 @@ sources:
   headless: true
   url: http://s3system:9000/sitemaps/bas-sitemap.xml
   properName: British Antarctic Survey
-  active: false
+  active: true
   domain: http://localhost
 - name : CCHDO
   url: https://cchdo.ucsd.edu/sitemap.xml

--- a/docker/lucene-connector.sparql
+++ b/docker/lucene-connector.sparql
@@ -11,8 +11,41 @@ INSERT DATA {
           "propertyChain": [
             "$literal"
           ],
-          "facet": false
-        }
+          "facet": true
+        },
+        {
+          "fieldName": "author",
+          "propertyChain": [
+            "https://schema.org/creator",
+            "https://schema.org/name"
+          ],
+          "facet": true
+        },
+        {
+          "fieldName": "license$0",
+          "propertyChain": [
+            "https://schema.org/Dataset",
+            "https://schema.org/license"
+          ],
+          "facet": true
+        },
+        {
+          "fieldName": "license$1",
+          "propertyChain": [
+            "https://schema.org/Dataset",
+            "https://schema.org/license",
+            "https://schema.org/license"
+          ],
+          "facet": true
+        },
+        {
+          "fieldName": "license$2",
+          "propertyChain": [
+            "https://schema.org/DataCatalog",
+            "https://schema.org/license",
+          ],
+          "facet": true
+        },
       ],
       "languages": [
         ""


### PR DESCRIPTION
I figured out how to make full-text index look at the right attributes to search for just authors, instead of doing it in SPARQL, which will make author searches much faster.

This will also let us do stuff like `luc:query '''keywords:ice''' ;` and it'll Just Work Like That, which is pretty cool, I think. 