### PR TITLE
Update the Sentry API and handle a few of this weeks errors

### DIFF
--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -225,6 +225,16 @@ class TestRoutes(unittest.TestCase):
 
     @patch('app.search.dataone.SolrDirectSearch.combined_search')
     @patch('app.search.gleaner.GleanerSearch.combined_search')
+    def test_invalid_page_number(self, gleaner, dataone):
+        gleaner.return_value = self.mock_result_set
+        dataone.return_value = self.mock_result_set
+
+        with app.test_client() as client:
+            response = client.get('/api/search?page=h4xx0r')
+            self.assertEqual(response.status, '400 BAD REQUEST')
+
+    @patch('app.search.dataone.SolrDirectSearch.combined_search')
+    @patch('app.search.gleaner.GleanerSearch.combined_search')
     def test_invalid_date(self, gleaner, dataone):
         gleaner.return_value = self.mock_result_set
         dataone.return_value = self.mock_result_set

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pygeojson==0.2.0
 python-dotenv==0.20.0
 requests==2.26.0
 requests-mock==1.9.3
-sentry-sdk==1.9.5
+sentry-sdk==1.10.1
 SPARQLWrapper==1.8.5
 typing-extensions==3.10.0.2
 validators==0.20.0


### PR DESCRIPTION
People are doing fun stuff like searching for `&&/bin/cat%20/etc/passwd` and page number `%SYSTEMROOT%\\win.ini`, so now we can handle that a little more gracefully.