### PR TITLE
Fix for multiple identifiers and bounding box issues

### DIFF
--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -432,9 +432,11 @@ class GleanerSearch(SearcherBase):
                 coords = plist.split(' ')
 
                 # Sometimes, this happens, and I think it is a mislabeled point,
-                # but... what exactly do people want us to do here?
+                # but there isn't much that can be done about it. The best you can do
+                # is to make a null polygon so the rest of the GeoJSON pipeline
+                # doesn't blow up.
                 if len(coords) < 4:
-                    return []
+                    return Polygon(coordinates=[])
 
                 return SearchResult.polygon_from_box({
                     'south': coords[0],

--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -428,6 +428,12 @@ class GleanerSearch(SearcherBase):
         if len(geometry['box']):
             def _build_bbox_polygon_from_points(plist):
                 coords = plist.split(' ')
+
+                # Sometimes, this happens, and I think it is a mislabeled point,
+                # but... what exactly do people want us to do here?
+                if len(coords) < 4:
+                    return []
+
                 return SearchResult.polygon_from_box({
                     'south': coords[0],
                     'west': coords[1],

--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -61,11 +61,9 @@ class GleanerSearch(SearcherBase):
         data_query = f"""
             SELECT
             (MAX(?relevance) AS ?score)
-            ?s
-            ?id
             ?url
             ?title
-            ?g
+            (GROUP_CONCAT(DISTINCT ?id ; separator=",") as ?id)
             (GROUP_CONCAT(DISTINCT ?license ; separator=",") as ?license)
             (GROUP_CONCAT(DISTINCT ?author ; separator=",") as ?author)
             (GROUP_CONCAT(DISTINCT ?abstract ; separator=",") as ?abstract)
@@ -129,9 +127,6 @@ class GleanerSearch(SearcherBase):
                     FILTER(ISLITERAL(?identifier)) .
                 }}
                 OPTIONAL {{
-                    ?sp prov:generated ?g  .
-                }}
-                OPTIONAL {{
 
                     {{ ?s schema:creator/schema:name ?author . }} UNION {{
                         ?catalog ?relationship ?s .
@@ -142,8 +137,9 @@ class GleanerSearch(SearcherBase):
 
                 {filter_query}
                 BIND(COALESCE(?identifier, ?s) AS ?id)
+                FILTER(ISLITERAL(?id))
             }}
-            GROUP BY ?s ?id ?url ?title ?g
+            GROUP BY ?url ?title ?g
         """
 
         return f"""

--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -365,6 +365,7 @@ class GleanerSearch(SearcherBase):
         # if we didn't do a text search, we didn't get a score.
         # This is a workaround for now.
         result['score'] = result.pop('score', 1)
+        result['id'] = result.pop('id', '').split(',')
         result['urls'] = []
 
         url = result.pop('url', None)
@@ -384,8 +385,9 @@ class GleanerSearch(SearcherBase):
             result['urls'].append(url)
         if sameAs is not None:
             result['urls'].append(sameAs)
-        if validators.url(result['id']):
-            result['urls'].append(result['id'])
+        for x in result['id']:
+            if validators.url(x):
+                result['urls'].append(x)
 
         # Each of the things in the geometry dict can be a list, so take
         # them from being a list of strings to being a list of PyGeoJSON objects

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -326,7 +326,6 @@ export function initializeMaps(lazy=false) {
 }
 
 export function addSearchResult(name, geometry) {
-
     // We're adding features twice in here because there are two maps.
     // If you only have one map, you only need to do this once.
     const arcticFeature = new GeoJSON().readFeature(geometry, {

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -14,7 +14,7 @@
 
    <ul id='main-content' class="results">
     {% for result in result_set.results %}
-      <li class="result" data-score={{ result.score }} data-source="{{ result.source }}" data-id="{{ result.id }}" id="{{ loop.index }}">
+      <li class="result" data-score={{ result.score }} data-source="{{ result.source }}" data-id="{{ result.id[0] }}" id="{{ loop.index }}">
         {% if result.geometry %}
           <!-- todo: separate out the result locations and template rendering
           so that we aren't calling these from each result object directly. Ideally,

--- a/app/tests/search/test_dataone.py
+++ b/app/tests/search/test_dataone.py
@@ -265,7 +265,7 @@ class TestSolrDirectSearch(unittest.TestCase):
         self.assertEqual(
             result.urls, ['https://search.dataone.org/view/An%20id', 'url1', 'url2', 'url3', 'url5', 'url6', 'url7'])
         self.assertEqual(result.title, 'A title'),
-        self.assertEqual(result.id, 'An id')
+        self.assertEqual(result.id, ['An id'])
         self.assertEqual(result.abstract, 'An abstract')
         self.assertEqual(result.geometry['text'], 'a location')
         self.assertEqual(result.keywords, ['keyword1', 'keyword2', 'keyword3'])
@@ -284,7 +284,7 @@ class TestSolrDirectSearch(unittest.TestCase):
         self.assertEqual(result.score, 4)
         self.assertEqual(result.doi, None)
         self.assertEqual(result.source, 'DataONE')
-        self.assertEqual(result.id, 'test1')
+        self.assertEqual(result.id, ['test1'])
         self.assertEqual(
             result.urls, ['https://search.dataone.org/view/test1'])
 

--- a/app/tests/search/test_gleaner.py
+++ b/app/tests/search/test_gleaner.py
@@ -64,31 +64,25 @@ class TestGleanerSearch(unittest.TestCase):
         self.assertEqual(results, expected)
         self.assertIn("luc:query '''test'''", self.search.query)
 
-
     @patch('SPARQLWrapper.SPARQLWrapper.query')
     def test_exact_text_search_double_quotes(self, query):
-        
 
         # Do the actual test
-       
+
         results = self.search.text_search(text='''"BioBasis  Zackenberg"''')
-        
-        self.assertIn('''luc:query \'\'\'\\"BioBasis  Zackenberg\\"'\'\'''', self.search.query)
+
+        self.assertIn(
+            '''luc:query \'\'\'\\"BioBasis  Zackenberg\\"'\'\'''', self.search.query)
 
     @patch('SPARQLWrapper.SPARQLWrapper.query')
     def test_exact_text_search_odd_double_quotes(self, query):
-        
 
         # Do the actual test
-       
+
         results = self.search.text_search(text='''"BioBasis " Zackenberg"''')
-        
-        self.assertIn(''' luc:query \'\'\'\\"BioBasis \\" Zackenberg\\"\\"\'\'\'''', self.search.query)
 
-
-
-    
-
+        self.assertIn(
+            ''' luc:query \'\'\'\\"BioBasis \\" Zackenberg\\"\\"\'\'\'''', self.search.query)
 
     @patch('SPARQLWrapper.SPARQLWrapper.query')
     def test_date_filter_none(self, query):
@@ -156,13 +150,12 @@ class TestGleanerSearch(unittest.TestCase):
             "FILTER(?end_date <= '2023-03-31'^^xsd:date)", self.search.query)
         self.assertIn("OFFSET 50", self.search.query)
 
-
     @patch('SPARQLWrapper.SPARQLWrapper.query')
     def test_search_author_name(self, query):
         query.return_value = self.mock_query
         results = self.search.combined_search(
             text="test",
-            author = 'Anonymous'
+            author='Anonymous'
         )
 
         self.assertIn("luc:query '''author:Anonymous'''", self.search.query)
@@ -280,15 +273,17 @@ class TestGleanerSearch(unittest.TestCase):
             'url': {'type': 'literal', 'value': 'url1'},
             'sameAs': {'type': 'literal', 'value': 'url2'},
             'temporal_coverage': {'type': 'literal', 'value': '2015-05-27/2015-06-20'},
-            'id': {'type': 'literal', 'value': 'http://www.mycooldataset.com'},
+            'id': {'type': 'literal', 'value': 'http://www.mycooldataset.com,test'},
             'keywords': {'type': 'literal', 'value': 'keyword1,keyword2,keyword3'}
         }
         result = self.search.convert_result(test_result)
         result.urls.sort()
         self.assertIsInstance(result, search.SearchResult)
+        self.assertEqual(result.id, ['http://www.mycooldataset.com', 'test'])
         self.assertEqual(
             result.urls, ['http://www.mycooldataset.com', 'url1', 'url2'])
         self.assertEqual(result.keywords, ['keyword1', 'keyword2', 'keyword3'])
+        self.assertEqual(result.id, ['http://www.mycooldataset.com', 'test'])
 
         self.assertEqual(result.source, "Gleaner")
 
@@ -322,9 +317,11 @@ class TestGleanerSearch(unittest.TestCase):
                 Point(coordinates=('55.7', '42.2')),
                 Point(coordinates=('180', '66')),
                 Point(coordinates=('50', '50')),
-                LineString(coordinates=[('120.1633', '39.3280'), ('123.7878', '40.445')]),
+                LineString(
+                    coordinates=[('120.1633', '39.3280'), ('123.7878', '40.445')]),
                 Polygon(coordinates=[[('120.1633', '39.3280'), ('123.7878', '40.445'),
-                         ('121', '41'), ('122.42', '39.77'), ('120.1633', '39.3280')]]),
-                Polygon(coordinates=[[('0.018', '-70.5397'), ('0.018', '-57.4443'), ('-10.4515', '-57.4443'), ('-10.4515', '-70.5397'), ('0.018', '-70.5397')]])
+                                      ('121', '41'), ('122.42', '39.77'), ('120.1633', '39.3280')]]),
+                Polygon(coordinates=[[('0.018', '-70.5397'), ('0.018', '-57.4443'),
+                                      ('-10.4515', '-57.4443'), ('-10.4515', '-70.5397'), ('0.018', '-70.5397')]])
             ]).geometries)
         self.assertEqual(result.source, "Gleaner")

--- a/app/tests/search/test_gleaner.py
+++ b/app/tests/search/test_gleaner.py
@@ -325,3 +325,32 @@ class TestGleanerSearch(unittest.TestCase):
                                       ('-10.4515', '-57.4443'), ('-10.4515', '-70.5397'), ('0.018', '-70.5397')]])
             ]).geometries)
         self.assertEqual(result.source, "Gleaner")
+
+    def test_convert_result_bad_bbox(self):
+        """ Sometimes you get a bbox with fewer than 4 coordinates to specify it """
+
+        test_result = {
+            'score': {'datatype': 'http://www.w3.org/2001/XMLSchema#double', 'type': 'literal', 'value': '0.375'},
+            'abstract': {'type': 'literal', 'value': 'This data file contains information'},
+            'title': {'type': 'literal', 'value': 'Iceflux trawl (SUIT & RMT) and ice stations'},
+            'url': {'type': 'literal', 'value': 'url1'},
+            'sameAs': {'type': 'literal', 'value': 'url2'},
+            'author': {'type': 'literal', 'value': 'author1,author2,author3'},
+            'spatial_coverage_text': {'type': 'literal', 'value': 'Antarctica,Greenland'},
+            'spatial_coverage_box': {'type': 'literal', 'value': '-70.5397 -10.4515 -57.4443'},
+            'id': {'type': 'literal', 'value': 'urn:uuid:696f9141-4e1a-5270-8c94-b0aabe0bbee7'},
+            'keywords': {'type': 'literal', 'value': 'keyword1,keyword2,keyword3'}
+        }
+        result = self.search.convert_result(test_result)
+        result.urls.sort()
+        self.assertIsInstance(result, search.SearchResult)
+        self.assertEqual(
+            len(result.geometry['geometry_collection'].geometries), 1)
+        self.assertEqual(len(result.geometry['text']), 2)
+        self.assertEqual(result.geometry['text'], ['Antarctica', 'Greenland'])
+        self.assertEqual(
+            result.geometry['geometry_collection'].geometries,
+            GeometryCollection([
+                Polygon(coordinates=[]),
+            ]).geometries)
+        self.assertEqual(result.source, "Gleaner")

--- a/app/tests/search/test_search_result.py
+++ b/app/tests/search/test_search_result.py
@@ -32,7 +32,7 @@ class TestSearchResult(unittest.TestCase):
         self.assertEqual(test_obj.title, kwargs_dict['title'])
         self.assertEqual(test_obj.urls, kwargs_dict['urls'])
         self.assertEqual(test_obj.abstract, kwargs_dict['abstract'])
-        self.assertEqual(test_obj.id, kwargs_dict['id'])
+        self.assertEqual(test_obj.id, [kwargs_dict['id']])
         self.assertEqual(test_obj.spatial_coverage,
                          kwargs_dict['spatial_coverage'])
         self.assertEqual(test_obj.temporal_coverage,
@@ -49,22 +49,22 @@ class TestSearchResult(unittest.TestCase):
 
     def test_init_doi(self):
         test_obj = search.SearchResult(id='doi:test_test', score=4)
-        self.assertEqual(test_obj.id, 'doi:test_test')
+        self.assertEqual(test_obj.id, ['doi:test_test'])
         self.assertEqual(test_obj.doi, 'doi:test_test')
         self.assertEqual(test_obj.urls, [])
 
     def test_doi_urls(self):
         test_obj = search.SearchResult(
             id='doi:test_test', score=4, urls=['http://test1', 'http://dx.doi.org/test_test'])
-        self.assertEqual(test_obj.id, 'doi:test_test')
+        self.assertEqual(test_obj.id, ['doi:test_test'])
         self.assertEqual(test_obj.doi, 'doi:test_test')
         test_obj.urls.sort()
         self.assertEqual(
             test_obj.urls, ['http://dx.doi.org/test_test', 'http://test1'])
 
-        test_obj_2 = search.SearchResult(id='doi:test2_test2', score=4, urls=[
+        test_obj_2 = search.SearchResult(id=['doi:test2_test2', 'test'], score=4, urls=[
                                          'http://test1', 'http://doi.org/test2_test2'])
-        self.assertEqual(test_obj_2.id, 'doi:test2_test2')
+        self.assertEqual(test_obj_2.id, ['doi:test2_test2', 'test'])
         self.assertEqual(test_obj_2.doi, 'doi:test2_test2')
         test_obj_2.urls.sort()
         self.assertListEqual(
@@ -72,7 +72,7 @@ class TestSearchResult(unittest.TestCase):
 
         test_obj_3 = search.SearchResult(id='doi:test3_test3', score=4, urls=[
                                         'http://test3', 'http://data.g-e-m.dk/datasets?doi=test3_test3'])
-        self.assertEqual(test_obj_3.id, 'doi:test3_test3')
+        self.assertEqual(test_obj_3.id, ['doi:test3_test3'])
         self.assertEqual(test_obj_3.doi, 'doi:test3_test3')
         test_obj_3.urls.sort()
         self.assertListEqual(
@@ -81,13 +81,13 @@ class TestSearchResult(unittest.TestCase):
 
         test_existing_doi = search.SearchResult(
             id='doi:test3', score=1, doi='existing_value')
-        self.assertEqual(test_existing_doi.id, 'doi:test3')
+        self.assertEqual(test_existing_doi.id, ['doi:test3'])
         self.assertEqual(test_existing_doi.doi, 'existing_value')
         self.assertListEqual(test_existing_doi.urls, [])
 
         test_doi_from_url = search.SearchResult(
             id='foo', score=4, urls=['http://test1', 'http://dx.doi.org/asdf'])
-        self.assertEqual(test_doi_from_url.id, 'foo')
+        self.assertEqual(test_doi_from_url.id, ['foo'])
         self.assertEqual(test_doi_from_url.doi, 'doi:asdf')
         test_doi_from_url.urls.sort()
         self.assertEqual(
@@ -98,13 +98,21 @@ class TestSearchResult(unittest.TestCase):
         self.assertEqual(test_obj.title, None)
         self.assertEqual(test_obj.urls, [])
         self.assertEqual(test_obj.abstract, "")
-        self.assertEqual(test_obj.id, 'test test test')
+        self.assertEqual(test_obj.id, ['test test test'])
         self.assertEqual(test_obj.spatial_coverage, None)
         self.assertEqual(test_obj.temporal_coverage, [])
         self.assertEqual(test_obj.score, 10.5)
 
 
-    
+    def test_multiple_ids(self):
+        test_obj = search.SearchResult(id=['test1', 'test2', 'test3'], score=10.5)
+        self.assertEqual(test_obj.title, None)
+        self.assertEqual(test_obj.urls, [])
+        self.assertEqual(test_obj.abstract, "")
+        self.assertEqual(test_obj.id, ['test1', 'test2', 'test3'])
+        self.assertEqual(test_obj.spatial_coverage, None)
+        self.assertEqual(test_obj.temporal_coverage, [])
+        self.assertEqual(test_obj.score, 10.5)
 
     def test_operators(self):
         a = search.SearchResult(id='a', score=1)


### PR DESCRIPTION
See more details in https://trello.com/c/VRZRjsgO - basically, @chantelleverhey found some search results that exposed a couple different bugs:

- I was including too many attributes in our query, which resulted in duplicate results, some of which had non-literal identifiers, which got turned into weird links in the result titles
- Some of the search results had geometries that were marked as bounding boxes, but with fewer than 4 coordinates, meaning that they are most likely mislabeled; I'm turning them into empty polygons so that GeoJSON doesn't bomb out in this circumstance.