### PR TITLE
Fix a little grab bag of front-end bugs

### DIFF
--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -450,8 +450,15 @@ class GleanerSearch(SearcherBase):
             geometry['box'] = []
 
         if len(geometry['circle']):
-            logger.info(
-                "We got a circle as a spatial coverage object!", result)
+            # Circles are rare and not recommended! But they are valid. The only one
+            # we have seen in the wild was defined to have a radius of one meter.
+            # For that reason, I feel okay about turning it into a point for now.
+            geometry['circle'] = list(map(
+                lambda coords: Point(coordinates=tuple(
+                    # the last thing in the list is the radius, which we are throwing out
+                    reversed(coords.split(' ')[0:2]))),
+                geometry['circle'].split(',')
+            ))
         else:
             geometry['circle'] = []
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -49,8 +49,8 @@
         <!-- for the search results showing up on the maps. Temporary until
         these geometries are returned with an API. -->
         <script type="text/javascript">
-        let resultGeometries = {};
-    </script>
+          var resultGeometries = {};
+        </script>
       {% endblock %}
   </body>
 </html>

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -14,7 +14,7 @@
 
    <ul id='main-content' class="results">
     {% for result in result_set.results %}
-      <li class="result" data-score={{ result.score }} data-source="{{ result.source }}" data-id="{{ result.id[0] }}" id="{{ loop.index }}">
+      <li class="result" data-score="{{ result.score }}" data-source="{{ result.source }}" data-id="{{ result.id[0] }}" id="{{ loop.index }}">
         {% if result.geometry %}
           <!-- todo: separate out the result locations and template rendering
           so that we aren't calling these from each result object directly. Ideally,

--- a/app/tests/search/test_gleaner.py
+++ b/app/tests/search/test_gleaner.py
@@ -354,3 +354,34 @@ class TestGleanerSearch(unittest.TestCase):
                 Polygon(coordinates=[]),
             ]).geometries)
         self.assertEqual(result.source, "Gleaner")
+
+        def test_convert_result_circle(self):
+            """ Sometimes you get a circle! Represented as a coordinate pair followed by a radius in meters.
+                For now, we are turning them into points.
+            """
+
+        test_result = {
+            'score': {'datatype': 'http://www.w3.org/2001/XMLSchema#double', 'type': 'literal', 'value': '0.375'},
+            'abstract': {'type': 'literal', 'value': 'This data file contains information'},
+            'title': {'type': 'literal', 'value': 'Iceflux trawl (SUIT & RMT) and ice stations'},
+            'url': {'type': 'literal', 'value': 'url1'},
+            'sameAs': {'type': 'literal', 'value': 'url2'},
+            'author': {'type': 'literal', 'value': 'author1,author2,author3'},
+            'spatial_coverage_text': {'type': 'literal', 'value': 'Antarctica,Greenland'},
+            'spatial_coverage_circle': {'type': 'literal', 'value': '73.25 -85.25 1'},
+            'id': {'type': 'literal', 'value': 'urn:uuid:696f9141-4e1a-5270-8c94-b0aabe0bbee7'},
+            'keywords': {'type': 'literal', 'value': 'keyword1,keyword2,keyword3'}
+        }
+        result = self.search.convert_result(test_result)
+        result.urls.sort()
+        self.assertIsInstance(result, search.SearchResult)
+        self.assertEqual(
+            len(result.geometry['geometry_collection'].geometries), 1)
+        self.assertEqual(len(result.geometry['text']), 2)
+        self.assertEqual(result.geometry['text'], ['Antarctica', 'Greenland'])
+        self.assertEqual(
+            result.geometry['geometry_collection'].geometries,
+            GeometryCollection([
+                Point(coordinates=('-85.25', '73.25')),
+            ]).geometries)
+        self.assertEqual(result.source, "Gleaner")


### PR DESCRIPTION
- There was an error message due to the fact that `resultGeometries` was getting declared when it was already defined
- Someone used GeoShape: circle (causing https://trello.com/c/hBuCTrUh)
- the values for `data-score` should have quotes around them