### PR TITLE
Indexing and triplestore fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ If you open a web inspector on the results, you can look for web elements with `
 ### Related Docker images
 A few of the setup and maintenence steps for the Polder Federated Search App require purpose-built Docker images. They can be found at:
 - `build-sitemap` in this repository
-- https://github.com/WDS-ITO/graphdb-docker
 
 ### Development
 I'd love for people to use this for all kinds of scientific data repository searches - please feel free to fork it, submit a PR, or ask questions. The [Customization](https://polder-crew.github.io/Federated-Search-Documentation/customization.html) section of the book will be particularly useful to you.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Note that the 30th of February has happened at least [twice](https://www.timeand
 
 Take a look at `helm/values-*.yaml` to customize this setup. Pay particular attention to `persistence` at the bottom; if you're running locally, you probably want `existing: false` in there.
 
+#### Testing your deployment
+Go to the site and do a search for something like "Greenland", "ice" or "penguin" - those each have lots of results from both DataONE and the triplestore.
+If you open a web inspector on the results, you can look for web elements with `class="result"`. POLDER-crawled results have a `data-source` attribute that’s set to `Gleaner`, and DataONE results have `data-source="DataONE"`. If you have both types, congratulations! You have a working federated search.
+
 ### Related Docker images
 A few of the setup and maintenence steps for the Polder Federated Search App require purpose-built Docker images. They can be found at:
 - `build-sitemap` in this repository

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -110,7 +110,7 @@ services:
       - 9999:7200
 
   s3system:
-    image: minio/minio
+    image: minio/minio:RELEASE.2022-10-24T18-35-07Z
     ports:
       - 54321:54321
       - 9000:9000

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -92,7 +92,7 @@ services:
     working_dir: /config
 
   triplestore:
-    image: wdsito/graphdb:10.0.0-free
+    image: ontotext/graphdb:10.1.0
     volumes:
       - triplestore:/opt
     environment:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
      - SERVICE_PORTS=9222
 
   webapp:
-    image: wdsito/polder-federated-search:1.43.9
+    image: wdsito/polder-federated-search:1.44.0
     depends_on:
       - triplestore
       - s3system

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -67,6 +67,8 @@ services:
       - MINIO_CLIENT_SECRET_KEY=${MINIO_SECRET_KEY}
       - MINIO_SERVER_HOST=s3system
       - MINIO_SERVER_PORT_NUMBER=9000
+      - MINIO_ROOT_USER=${MINIO_ACCESS_KEY}
+      - MINIO_ROOT_PASSWORD=${MINIO_SECRET_KEY}
     volumes:
       - ./:/config
     working_dir: /config

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.43.9"
+appVersion: "1.44.0"

--- a/helm/templates/crawl.yaml
+++ b/helm/templates/crawl.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: crawl
 spec:
-  schedule: "0 0 * * 3"
+  schedule: {{ .Values.crawlSchedule }}
   jobTemplate:
     spec:
       template:

--- a/helm/templates/crawl.yaml
+++ b/helm/templates/crawl.yaml
@@ -67,7 +67,7 @@ spec:
               mountPath: /config
           containers:
           - name: write-to-triplestore
-            image: bitnami/minio-client:2022.9.16
+            image: minio/mc:RELEASE.2022-11-17T21-20-39Z
             env:
             - name: MINIO_CLIENT_ACCESS_KEY
               valueFrom:
@@ -86,7 +86,7 @@ spec:
             command:
             # the first line of the following bash command is supposed to happen automatically, according to
             # the documentation on docker hub, but it does not.
-            - /bin/bash
+            - /bin/sh
             - -c
             - >
               mc config host add minio "http://${MINIO_SERVER_HOST}:${MINIO_SERVER_PORT_NUMBER}" "${MINIO_CLIENT_ACCESS_KEY}" "${MINIO_CLIENT_SECRET_KEY}" &&

--- a/helm/templates/gleaner-deployment.yaml
+++ b/helm/templates/gleaner-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: "5"
       containers:
       - name: triplestore
-        image: wdsito/graphdb:10.0.0-free
+        image: ontotext/graphdb:10.1.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - mountPath: /data/graphdb

--- a/helm/templates/gleaner-deployment.yaml
+++ b/helm/templates/gleaner-deployment.yaml
@@ -59,7 +59,7 @@ spec:
         - name: GDB_JAVA_OPTS
           value: {{ .Values.GDB_JAVA_OPTS }}
       - name: s3system
-        image: minio/minio
+        image: minio/minio:RELEASE.2022-10-24T18-35-07Z
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - mountPath: /data
@@ -72,12 +72,12 @@ spec:
         - containerPort: {{ .Values.s3system_service.ui_port }}
         - containerPort: {{ .Values.s3system_service.api_port }}
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           valueFrom:
             secretKeyRef:
               key:  minioAccessKey
               name: {{ .Release.Name }}-secrets
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               key:  minioSecretKey

--- a/helm/templates/recreate-index.yaml
+++ b/helm/templates/recreate-index.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       template:
         metadata:
-          name: crawl
+          name: recreate-index
         spec:
           restartPolicy: Never
           volumes:

--- a/helm/templates/recreate-index.yaml
+++ b/helm/templates/recreate-index.yaml
@@ -26,7 +26,7 @@ spec:
               name: polder-repo-config
           initContainers:
           - name: remove-minio-files
-            image: bitnami/minio-client:2022.9.16
+            image: minio/mc:RELEASE.2022-11-17T21-20-39Z
             env:
             - name: MINIO_CLIENT_ACCESS_KEY
               valueFrom:
@@ -127,7 +127,7 @@ spec:
             - "{{- include "gleaner.triplestore.endpoint" . }}/repositories/{{ .Values.storageNamespace }}/statements"
           containers:
           - name: write-to-triplestore
-            image: bitnami/minio-client:2022.9.16
+            image: minio/mc:RELEASE.2022-11-17T21-20-39Z
             env:
             - name: MINIO_CLIENT_ACCESS_KEY
               valueFrom:
@@ -146,7 +146,7 @@ spec:
             command:
             # the first line of the following bash command is supposed to happen automatically, according to
             # the documentation on docker hub, but it does not.
-            - /bin/bash
+            - /bin/sh
             - -c
             - >
               mc config host add minio "http://${MINIO_SERVER_HOST}:${MINIO_SERVER_PORT_NUMBER}" "${MINIO_CLIENT_ACCESS_KEY}" "${MINIO_CLIENT_SECRET_KEY}" &&

--- a/helm/templates/setup-gleaner.yaml
+++ b/helm/templates/setup-gleaner.yaml
@@ -162,7 +162,7 @@ spec:
           mountPath: /config
       containers:
       - name: write-to-triplestore
-        image: bitnami/minio-client:2022.9.16
+        image: minio/mc:RELEASE.2022-11-17T21-20-39Z
         env:
         - name: MINIO_CLIENT_ACCESS_KEY
           valueFrom:
@@ -181,7 +181,7 @@ spec:
         command:
         # the first line of the following bash command is supposed to happen automatically, according to
         # the documentation on docker hub, but it does not.
-        - /bin/bash
+        - /bin/sh
         - -c
         - >
           mc config host add minio "http://${MINIO_SERVER_HOST}:${MINIO_SERVER_PORT_NUMBER}" "${MINIO_CLIENT_ACCESS_KEY}" "${MINIO_CLIENT_SECRET_KEY}" &&

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -127,3 +127,5 @@ storageNamespace: polder
 ## PersistentVolumeClaim. created for you.
 persistence:
   existing: true
+
+crawlSchedule: "0 0 * * 1" # every Monday

--- a/helm/values-local.yaml
+++ b/helm/values-local.yaml
@@ -121,3 +121,5 @@ storageNamespace: polder
 ## PersistentVolumeClaim. created for you.
 persistence:
   existing: false
+
+crawlSchedule: "30 08 * * *" # every morning at 8:30

--- a/helm/values-local.yaml
+++ b/helm/values-local.yaml
@@ -122,4 +122,6 @@ storageNamespace: polder
 persistence:
   existing: false
 
-crawlSchedule: "30 08 * * *" # every morning at 8:30
+# 30th of February run, will never be run automatically, only when we trigger it
+# Yes, this is cursed, but this is the only way you can put a manual-only job in a Helm chart
+crawlSchedule: "0 0 30 2 0"

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -127,3 +127,5 @@ storageNamespace: polder
 ## PersistentVolumeClaim. created for you.
 persistence:
   existing: true
+
+crawlSchedule: "0 0 * * 3" # every Wednesday

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polder-federated-search",
   "license": "BSD-3-Clause",
-  "version": "1.43.9",
+  "version": "1.44.0",
   "description": "A federated search for the polar research community",
   "author": "Melinda Minch <melindaminch@oceannetworks.ca>",
   "repository": "https://github.com/WDS-ITO/polder-federated-search",


### PR DESCRIPTION
For https://trello.com/c/o3ccHYtp and https://trello.com/c/524m7c6P 
- fixing a bug that happens when we re-crawl / reindex
- staggering the development and production crawl cycles
- adding some documentation
- Using an official GraphDB image instead of one we built ourselves (when this goes to production the [graphdb-docker](https://github.com/WDS-ITO/graphdb-docker) repo will be able to be deleted and so will its associated Docker images)