### PR TITLE
Proof of concept: index CCADI

### DIFF
--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -136,7 +136,7 @@ class GleanerSearch(SearcherBase):
                 }}
 
                 {filter_query}
-                BIND(COALESCE(?identifier, ?s) AS ?id)
+                BIND(COALESCE(?identifier, ?url, ?s) AS ?id)
                 FILTER(ISLITERAL(?id))
             }}
             GROUP BY ?url ?title ?g

--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -165,7 +165,6 @@ class GleanerSearch(SearcherBase):
                 ?spatial_coverage_circle
                 ?spatial_coverage_point
                 ?author
-                ?g
             {{
                 {{
                     {count_query}

--- a/build-sitemap/build-sitemaps.sh
+++ b/build-sitemap/build-sitemaps.sh
@@ -47,3 +47,18 @@ mc cp bas-sitemap.xml minio/sitemaps/bas-sitemap.xml
 python3 /usr/local/bin/index-gcmd.py
 
 mc cp gcmd-sitemap.xml minio/sitemaps/gcmd-sitemap.xml
+
+# Build the CCADI sitemap
+
+rm -f ccadi-sitemap.xml
+
+# build the skeleton of the XML sitemap
+printf '<?xml version="1.0" encoding="UTF-8"?>\n' >> ccadi-sitemap.xml
+printf '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemalocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">' >> bas-sitemap.xml
+for i in http://hedeby.uwaterloo.ca/api/metadata?page={0..150}
+    do printf "<url><loc>${i}</loc></url>"
+done
+
+printf "</urlset>" >> ccadi-sitemap.xml
+
+mc cp ccadi-sitemap.xml minio/sitemaps/ccadi-sitemap.xml

--- a/docker/build-ccadi-sitemap.sh
+++ b/docker/build-ccadi-sitemap.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# 'download' does not work for some reason, but 'public' permissions do
+mc stat minio/sitemaps || mc mb minio/sitemaps
+mc policy set public minio/sitemaps
+
+rm -f ccadi-sitemap.xml
+
+# build the skeleton of the XML sitemap
+printf '<?xml version="1.0" encoding="UTF-8"?>\n' >> ccadi-sitemap.xml
+printf '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemalocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">' >> bas-sitemap.xml
+for i in http://hedeby.uwaterloo.ca/api/metadata?page={0..150}
+    do printf "<url><loc>${i}</loc></url>" >> ccadi-sitemap.xml
+done
+
+printf "</urlset>" >> ccadi-sitemap.xml
+
+mc cp ccadi-sitemap.xml minio/sitemaps/ccadi-sitemap.xml

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
     - "http://triplestore:7200/repositories/polder/statements"
 
   sitemap-setup:
-    image: wdsito/build-sitemap:1.5
+    image: wdsito/build-sitemap:1.44.1
     depends_on:
     - s3system
     profiles:
@@ -129,7 +129,7 @@ services:
      - SERVICE_PORTS=9222
 
   webapp:
-    image: wdsito/polder-federated-search:1.44.0
+    image: wdsito/polder-federated-search:1.44.1
     depends_on:
       - triplestore
       - s3system

--- a/docker/gleaner.yaml
+++ b/docker/gleaner.yaml
@@ -57,3 +57,9 @@ sources:
   properName: Global Change Master Directory
   active: true
   domain: http://localhost
+- name: ccadi
+  type: sitemap
+  headless: false
+  url: http://s3system:9000/sitemaps/ccadi-sitemap.xml
+  properName: Canadian Consortium for Arctic Data Interoperability
+  domain: http://hedeby.uwaterloo.ca

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.44.0"
+appVersion: "1.44.1"

--- a/helm/templates/gleaner-config.yaml
+++ b/helm/templates/gleaner-config.yaml
@@ -67,6 +67,6 @@ data:
     - name: ccadi
       type: sitemap
       headless: false
-      url: http://s3system:9000/sitemaps/ccadi-sitemap.xml
+      url: http://s3system-svc:{{ .Values.s3system_service.api_port }}/sitemaps/ccadi-sitemap.xml
       properName: Canadian Consortium for Arctic Data Interoperability
       domain: http://hedeby.uwaterloo.ca

--- a/helm/templates/gleaner-config.yaml
+++ b/helm/templates/gleaner-config.yaml
@@ -64,3 +64,9 @@ data:
       properName: Global Change Master Directory
       active: true
       domain: http://localhost
+    - name: ccadi
+      type: sitemap
+      headless: false
+      url: http://s3system:9000/sitemaps/ccadi-sitemap.xml
+      properName: Canadian Consortium for Arctic Data Interoperability
+      domain: http://hedeby.uwaterloo.ca

--- a/helm/templates/setup-gleaner.yaml
+++ b/helm/templates/setup-gleaner.yaml
@@ -113,9 +113,9 @@ spec:
           mountPath: /context
         workingDir: /context
       # Dynamically create the sitemaps for BAS and GCMD, and put
-      # them somewherethat Gleaner can use to crawl
+      # them somewhere that Gleaner can use to crawl
       - name: build-sitemap
-        image: wdsito/build-sitemap:1.5
+        image: wdsito/build-sitemap::{{ .Values.image.tag | default .Chart.AppVersion }}
         env:
         - name: MINIO_CLIENT_ACCESS_KEY
           valueFrom:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polder-federated-search",
   "license": "BSD-3-Clause",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "description": "A federated search for the polar research community",
   "author": "Melinda Minch <melindaminch@oceannetworks.ca>",
   "repository": "https://github.com/WDS-ITO/polder-federated-search",


### PR DESCRIPTION
https://trello.com/c/xxtod30P

An ideal solution for this would be something like I outline in  https://trello.com/c/3hYsa6iE, where you could give an API endpoint template URL to Gleaner, and it would page through the API in an automated way and ingest the JSON-LD that it can get there.

But for now, we can index CCADI by asking Gleaner to crawl its API endpoint, by building a sitemap that pages through it.

I had to slightly modify the SPARQL query that we use in order to get CCADI search results to show up, but otherwise I could just plug it into our system, which says great things about the CCADI developers.