### PR TITLE
some word changes

### DIFF
--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -16,13 +16,13 @@
      </a>
 <h3>Multiple terms can be combined together with boolean operators to form a more complex and desirable search parameter as shown below:</h3>
 <h4>Note all the boolean operators must be in ALL CAPS.</h4>
-<p>- 'ice~' -> search would return all similar terms spelling wise to ice.</p>
-<p>- 'green^4 ice'-> boosts the relevance of green in the search.</p>
-<p>- 'green ice' OR 'temperature' -> documents may contain 'green ice' or 'temperature'.</p>
-<p>- 'green ice' AND 'temperature' -> documents must contain 'green ice' and 'temperature'.</p>
-<p>- '+green ice' -> documents must contain 'green' and may contain both terms.</p>
-<p>- 'green ice' NOT 'planktons' -> documents must contain 'green ice' and not 'planktons'.</p>
-<p>- ('green' OR 'ice') AND 'temperature' -> documents must contain temperature and either 'green' or 'ice' may exist.</p>
+<p>- 'ice~' -> search would return all similar terms spelling wise to ice like dice, rice etc.</p>
+<p>- 'green^4 ice'-> boosts the relevance of green in the search, search results containing green would be prioritized</p>
+<p>- 'green ice' OR 'temperature' -> search results may contain 'green ice' or 'temperature'.</p>
+<p>- 'green ice' AND 'temperature' -> search results must contain 'green ice' and 'temperature'.</p>
+<p>- '+green ice' -> search results must contain 'green' and may contain 'green ice'.</p>
+<p>- 'green ice' NOT 'planktons' -> search results must contain 'green ice' and not 'planktons'.</p>
+<p>- ('green' OR 'ice') AND 'temperature' -> search results must contain temperature and either 'green' or 'ice' may exist.</p>
  <p>Find out more by reading the <a class="about__link" href="https://polder-crew.github.io/Federated-Search-Documentation/intro.html" rel="noopener" target="_blank">documentation book</a> or exploring the <a class="about__link" href="https://github.com/nein09/polder-federated-search" rel="noopener" target="_blank">GitHub repository</a>.</p>
   <p>If you'd like to send us questions or comments directly, you are welcome to <a class="about__link" href="mailto:cverhey@oceannetworks.ca">email us</a>.</p>
 </div>

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -16,7 +16,7 @@
      </a>
 <h3>Multiple terms can be combined together with boolean operators to form a more complex and desirable search parameter as shown below:</h3>
 <h4>Note all the boolean operators must be in ALL CAPS.</h4>
-<p>- 'ice~' -> search would return all similar terms spelling wise to ice like dice, rice etc.</p>
+<p>- 'ice~' -> search would return all similar terms spelling wise to ice like dice,icey and iced etc.</p>
 <p>- 'green^4 ice'-> boosts the relevance of green in the search, search results containing green would be prioritized</p>
 <p>- 'green ice' OR 'temperature' -> search results may contain 'green ice' or 'temperature'.</p>
 <p>- 'green ice' AND 'temperature' -> search results must contain 'green ice' and 'temperature'.</p>


### PR DESCRIPTION
These were the changes suggested by CJ;
-'ice~'  ->  Stating the examples of words similar to ice spelling is
- 'green^4 ice' -> Stating what happens when 'green' relevance is boosted, 'green' becomes prioritized.
- '+green ice' -> breaking down what both terms are into 'green ice' 
- Also, He suggested we use 'search results' instead of 'documents' because the users may not only get PDFs.
