### PR TITLE
SPARQL full text search error

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -92,7 +92,7 @@ services:
     working_dir: /config
 
   triplestore:
-    image: ontotext/graphdb:10.1.0
+    image: ontotext/graphdb:10.1.3
     volumes:
       - triplestore:/opt
     environment:

--- a/docker/lucene-connector.sparql
+++ b/docker/lucene-connector.sparql
@@ -6,12 +6,54 @@ INSERT DATA {
     {
       "fields": [
         {
-          "fieldName": "fts",
+          "fieldName": "fts$0",
           "fieldNameTransform": "predicate.localName",
           "propertyChain": [
+            "https://schema.org/creator",
             "$literal"
           ],
-          "facet": true
+        },
+        {
+          "fieldName": "fts$1",
+          "propertyChain": [
+            "https://schema.org/license",
+            "$literal"
+          ],
+        },
+        {
+          "fieldName": "fts$2",
+          "propertyChain": [
+            "https://schema.org/name",
+            "$literal"
+          ],
+        },
+        {
+          "fieldName": "fts$3",
+          "propertyChain": [
+            "https://schema.org/description",
+            "$literal"
+          ],
+        },
+        {
+          "fieldName": "fts$4",
+          "propertyChain": [
+            "https://schema.org/temporalCoverage",
+            "$literal"
+          ],
+        },
+        {
+          "fieldName": "fts$5",
+          "propertyChain": [
+            "https://schema.org/keywords",
+            "$literal"
+          ],
+        },
+        {
+          "fieldName": "fts$6",
+          "propertyChain": [
+            "https://schema.org/spatialCoverage",
+            "$literal"
+          ],
         },
         {
           "fieldName": "author",
@@ -22,27 +64,10 @@ INSERT DATA {
           "facet": true
         },
         {
-          "fieldName": "license$0",
+          "fieldName": "license",
           "propertyChain": [
-            "https://schema.org/Dataset",
-            "https://schema.org/license"
-          ],
-          "facet": true
-        },
-        {
-          "fieldName": "license$1",
-          "propertyChain": [
-            "https://schema.org/Dataset",
             "https://schema.org/license",
-            "https://schema.org/license"
-          ],
-          "facet": true
-        },
-        {
-          "fieldName": "license$2",
-          "propertyChain": [
-            "https://schema.org/DataCatalog",
-            "https://schema.org/license",
+            "$literal"
           ],
           "facet": true
         },

--- a/docker/lucene-connector.sparql
+++ b/docker/lucene-connector.sparql
@@ -17,7 +17,7 @@ INSERT DATA {
           "fieldName": "author",
           "propertyChain": [
             "https://schema.org/creator",
-            "https://schema.org/name"
+            "$literal"
           ],
           "facet": true
         },

--- a/docker/lucene-connector.sparql
+++ b/docker/lucene-connector.sparql
@@ -9,49 +9,88 @@ INSERT DATA {
           "fieldName": "fts$0",
           "fieldNameTransform": "predicate.localName",
           "propertyChain": [
-            "https://schema.org/creator",
-            "$literal"
+            "https://schema.org/name"
           ],
         },
         {
           "fieldName": "fts$1",
-          "propertyChain": [
-            "https://schema.org/license",
-            "$literal"
-          ],
-        },
-        {
-          "fieldName": "fts$2",
+          "fieldNameTransform": "predicate.localName",
           "propertyChain": [
             "https://schema.org/name",
             "$literal"
           ],
         },
         {
-          "fieldName": "fts$3",
+          "fieldName": "fts$2",
+          "fieldNameTransform": "predicate.localName",
           "propertyChain": [
             "https://schema.org/description",
+          ],
+        },
+        {
+          "fieldName": "fts$3",
+          "fieldNameTransform": "predicate.localName",
+          "propertyChain": [
+            "https://schema.org/creator",
             "$literal"
           ],
         },
         {
           "fieldName": "fts$4",
+          "fieldNameTransform": "predicate.localName",
           "propertyChain": [
-            "https://schema.org/temporalCoverage",
-            "$literal"
+            "https://schema.org/license",
           ],
         },
         {
           "fieldName": "fts$5",
+          "fieldNameTransform": "predicate.localName",
+          "propertyChain": [
+            "https://schema.org/license",
+            "$literal"
+          ],
+        },
+        {
+          "fieldName": "fts$6",
+          "fieldNameTransform": "predicate.localName",
+          "propertyChain": [
+            "https://schema.org/temporalCoverage",
+          ],
+        },
+        {
+          "fieldName": "fts$7",
+          "fieldNameTransform": "predicate.localName",
+          "propertyChain": [
+            "https://schema.org/keywords",
+          ],
+        },
+        {
+          "fieldName": "fts$8",
+          "fieldNameTransform": "predicate.localName",
           "propertyChain": [
             "https://schema.org/keywords",
             "$literal"
           ],
         },
         {
-          "fieldName": "fts$6",
+          "fieldName": "fts$9"
+          "fieldNameTransform": "predicate.localName",,
           "propertyChain": [
             "https://schema.org/spatialCoverage",
+          ],
+        },
+        {
+          "fieldName": "fts$10",
+          "fieldNameTransform": "predicate.localName",
+          "propertyChain": [
+            "https://schema.org/variableMeasured",
+          ],
+        },
+        {
+          "fieldName": "fts$11",
+          "fieldNameTransform": "predicate.localName",
+          "propertyChain": [
+            "https://schema.org/variableMeasured",
             "$literal"
           ],
         },

--- a/helm/templates/gleaner-deployment.yaml
+++ b/helm/templates/gleaner-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: "5"
       containers:
       - name: triplestore
-        image: ontotext/graphdb:10.1.0
+        image: ontotext/graphdb:10.1.3
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - mountPath: /data/graphdb


### PR DESCRIPTION
For https://trello.com/c/lRGMaOyz

The problem was basically that we were telling the full-text search in GraphDB to index every single field literal, regardless of its type, and then it was trying to look for text that had words in a certain order in a `boolean` field. Which isn't going to happen.

The fix is to explicitly tell the full-text search connector which fields it should index. I also updated the GraphDB Docker image while I was in here, because they made a few security fixes.