### PR TITLE
Set a TTL for helm jobs to live

### DIFF
--- a/helm/templates/setup-gleaner.yaml
+++ b/helm/templates/setup-gleaner.yaml
@@ -3,6 +3,7 @@ kind: Job
 metadata:
   name: setup-gleaner
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       name: setup-gleaner


### PR DESCRIPTION
This makes our upgrade work better, during deployments.