### PR TITLE
Move to new CCADI API crawl method and update other Docker images

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -5,7 +5,7 @@ volumes:
 services:
 
   gleaner-setup:
-    image: nsfearthcube/gleaner:dev-v3.0.7-development
+    image: nsfearthcube/gleaner:v3.0.8_fix129
     command: -cfg gleaner -setup
     depends_on:
       - triplestore
@@ -23,7 +23,7 @@ services:
     working_dir: /config
 
   triplestore-setup:
-    image: curlimages/curl:7.85.0
+    image: curlimages/curl:7.88.1
     depends_on:
     - triplestore
     volumes:
@@ -57,7 +57,7 @@ services:
     - "http://triplestore:7200/repositories/polder/statements"
 
   sitemap-setup:
-    image: wdsito/build-sitemap:1.45.0
+    image: wdsito/build-sitemap:1.46.0
     depends_on:
     - s3system
     profiles:
@@ -74,7 +74,7 @@ services:
     working_dir: /config
 
   gleaner:
-    image: nsfearthcube/gleaner:dev-v3.0.7-development
+    image: nsfearthcube/gleaner:v3.0.8_fix129
     command: -cfg gleaner
     depends_on:
       - triplestore
@@ -92,7 +92,7 @@ services:
     working_dir: /config
 
   triplestore:
-    image: ontotext/graphdb:10.1.3
+    image: ontotext/graphdb:10.2.0
     volumes:
       - triplestore:/opt
     environment:
@@ -129,7 +129,7 @@ services:
      - SERVICE_PORTS=9222
 
   webapp:
-    image: wdsito/polder-federated-search:1.45.0
+    image: wdsito/polder-federated-search:1.46.0
     depends_on:
       - triplestore
       - s3system

--- a/docker/gleaner.yaml
+++ b/docker/gleaner.yaml
@@ -64,6 +64,13 @@ sources:
   domain: http://hedeby.uwaterloo.ca
   apipagelimit: 500
   active: true
+- sourcetype: api
+  name: pdc
+  url: "http://hedeby.uwaterloo.ca/api/metadata?page=%d"
+  properName: pdc
+  domain: http://hedeby.uwaterloo.ca
+  apipagelimit: 500
+  active: true
 - name: datastream
   type: sitemap
   headless: false

--- a/docker/gleaner.yaml
+++ b/docker/gleaner.yaml
@@ -57,12 +57,12 @@ sources:
   properName: Global Change Master Directory
   active: true
   domain: http://localhost
-- name: ccadi
-  type: sitemap
-  headless: false
-  url: http://s3system:9000/sitemaps/ccadi-sitemap.xml
-  properName: Canadian Consortium for Arctic Data Interoperability
+- sourcetype: api
+  name: ccadi
+  url: "http://hedeby.uwaterloo.ca/aggregator/metadata?page=%d"
+  properName: ccadi
   domain: http://hedeby.uwaterloo.ca
+  apipagelimit: 500
   active: true
 - name: datastream
   type: sitemap

--- a/helm/templates/crawl.yaml
+++ b/helm/templates/crawl.yaml
@@ -32,7 +32,7 @@ spec:
               value: "5"
           initContainers:
           - name: get-contextfiles
-            image: curlimages/curl:7.85.0
+            image: curlimages/curl:7.88.1
             command:
             - curl
             - -O
@@ -42,7 +42,7 @@ spec:
               mountPath: /context
             workingDir: /context
           - name: gleaner-index
-            image: nsfearthcube/gleaner:dev-v3.0.7-development
+            image: nsfearthcube/gleaner:v3.0.8_fix129
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             args:
             - -cfg

--- a/helm/templates/gleaner-config.yaml
+++ b/helm/templates/gleaner-config.yaml
@@ -65,9 +65,16 @@ data:
       active: true
       domain: http://localhost
     - sourcetype: api
-      name: ccadi-pdc
+      name: ccadi
       url: "http://hedeby.uwaterloo.ca/aggregator/metadata?page=%d"
       properName: ccadi
+      domain: http://hedeby.uwaterloo.ca
+      apipagelimit: 500
+      active: true
+    - sourcetype: api
+      name: pdc
+      url: "http://hedeby.uwaterloo.ca/api/metadata?page=%d"
+      properName: pdc
       domain: http://hedeby.uwaterloo.ca
       apipagelimit: 500
       active: true

--- a/helm/templates/gleaner-config.yaml
+++ b/helm/templates/gleaner-config.yaml
@@ -64,12 +64,12 @@ data:
       properName: Global Change Master Directory
       active: true
       domain: http://localhost
-    - name: ccadi-pdc
-      type: sitemap
-      headless: false
-      url: http://s3system-svc:{{ .Values.s3system_service.api_port }}/sitemaps/ccadi-sitemap.xml
-      properName: Polar Data Catalog (via Canadian Consortium for Arctic Data Interoperability)
+    - sourcetype: api
+      name: ccadi-pdc
+      url: "http://hedeby.uwaterloo.ca/aggregator/metadata?page=%d"
+      properName: ccadi
       domain: http://hedeby.uwaterloo.ca
+      apipagelimit: 500
       active: true
     - name: datastream
       type: sitemap

--- a/helm/templates/gleaner-deployment.yaml
+++ b/helm/templates/gleaner-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: "5"
       containers:
       - name: triplestore
-        image: ontotext/graphdb:10.1.3
+        image: ontotext/graphdb:10.2.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - mountPath: /data/graphdb

--- a/helm/templates/recreate-index.yaml
+++ b/helm/templates/recreate-index.yaml
@@ -51,7 +51,7 @@ spec:
               mc config host add minio "http://${MINIO_SERVER_HOST}:${MINIO_SERVER_PORT_NUMBER}" "${MINIO_CLIENT_ACCESS_KEY}" "${MINIO_CLIENT_SECRET_KEY}" &&
               mc rm -r --force minio/{{ .Values.storageNamespace }}
           - name: get-contextfiles
-            image: curlimages/curl:7.85.0
+            image: curlimages/curl:7.88.1
             command:
             - curl
             - -O
@@ -61,7 +61,7 @@ spec:
               mountPath: /context
             workingDir: /context
           - name: gleaner-index
-            image: nsfearthcube/gleaner:dev-v3.0.7-development
+            image: nsfearthcube/gleaner:v3.0.8_fix129
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             args:
             - -cfg
@@ -86,7 +86,7 @@ spec:
               mountPath: /config
           # The easiest way is just to remove the repository and recreate it
           - name: clear-triplestore
-            image: curlimages/curl:7.85.0
+            image: curlimages/curl:7.88.1
             workingDir: /config
             volumeMounts:
             - name: polder-repo-config

--- a/helm/templates/setup-gleaner.yaml
+++ b/helm/templates/setup-gleaner.yaml
@@ -35,7 +35,7 @@ spec:
       initContainers:
         # Literally wait for GraphDB to come up so we can create a repository
       - name: wait-for-triplestore-up
-        image: curlimages/curl:7.85.0
+        image: curlimages/curl:7.88.1
         command:
         - /bin/sh
         - -c
@@ -47,7 +47,7 @@ spec:
           done
       # Next, create the graphdb repository that we want to use for this app
       - name: setup-triplestore
-        image: curlimages/curl:7.85.0
+        image: curlimages/curl:7.88.1
         workingDir: /config
         volumeMounts:
         - name: polder-repo-config
@@ -80,7 +80,7 @@ spec:
         - "{{- include "gleaner.triplestore.endpoint" . }}/repositories/{{ .Values.storageNamespace }}/statements"
       # Run gleaner setup, which creates cloud storage buckets
       - name: gleaner-setup
-        image: nsfearthcube/gleaner:dev-v3.0.7-development
+        image: nsfearthcube/gleaner:v3.0.8_fix129
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -cfg
@@ -104,7 +104,7 @@ spec:
           subPath: gleaner.yaml
       # We need the latest schema.org context, so fetch it
       - name: get-contextfiles
-        image: curlimages/curl:7.85.0
+        image: curlimages/curl:7.88.1
         command:
         - curl
         - -O
@@ -138,7 +138,7 @@ spec:
         workingDir: /context
       # Finally, index our data repositories!
       - name: gleaner-initial-index
-        image: nsfearthcube/gleaner:dev-v3.0.7-development
+        image: nsfearthcube/gleaner:v3.0.8_fix129
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -cfg


### PR DESCRIPTION
For https://trello.com/c/3hYsa6iE - the Gleaner changes to support this have been officially released, so we can deploy them now!

I updated some other images to the latest while I was at it.